### PR TITLE
chore: remove unecessary console.log

### DIFF
--- a/src/helpers/requestDeduplicator.ts
+++ b/src/helpers/requestDeduplicator.ts
@@ -13,7 +13,6 @@ export default function serve(id, action, args) {
     const requestPromise = action(...args)
       .then(result => result)
       .catch(e => {
-        console.log('[requestDeduplicator] request error', e);
         throw e;
       })
       .finally(() => {


### PR DESCRIPTION
The `console.log` is unecessary, since we've already caught, and sent the error to Sentry, inside the action function.

In addition, it's only printing the generic error thrown here, which isn't providing much info
https://github.com/snapshot-labs/blockfinder/blob/2fbc1b9e59b0f13f86fe3b112a55239c544d8b2d/src/graphql/blocks.ts#L74