### PR TITLE
fix: throw meaningful error on invalid timestamp

### DIFF
--- a/src/graphql/blocks.ts
+++ b/src/graphql/blocks.ts
@@ -60,6 +60,12 @@ export default async function query(_parent, args) {
   const ts: any = where?.ts || 0;
   if (!Array.isArray(networks)) networks = [networks];
 
+  if (ts > Math.floor(Date.now() / 1000) || ts <= 0) {
+    throw new GraphQLError('timestamp must be in the past', {
+      extensions: { code: 'INVALID_TIMESTAMP' }
+    });
+  }
+
   try {
     const blockNums = await Promise.all(networks.map(network => tsToBlockNum(network, ts)));
     const blockNumsObj = Object.fromEntries(

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -40,4 +40,69 @@ describe('POST /', () => {
       }
     });
   }, 15e3);
+
+  it('returns a GraphQLError when giving invalid network', async () => {
+    const response = await request(HOST)
+      .post('/')
+      .set('Content-type', 'application/json')
+      .send(
+        JSON.stringify({
+          query:
+            'query {  blocks (where: { ts: 1640000000, network_in: ["1", "4"] }) {network number}}',
+          variables: null
+        })
+      );
+
+    expect(response.body.errors).toEqual([
+      {
+        extensions: {
+          code: 'INVALID_NETWORK'
+        },
+        locations: [
+          {
+            column: 10,
+            line: 1
+          }
+        ],
+        message: 'invalid network',
+        path: ['blocks']
+      }
+    ]);
+  }, 15e3);
+
+  it.each([
+    ['in the future', Math.floor((Date.now() + 1000 * 60) / 1000)],
+    ['0', 0],
+    ['negative', -500]
+  ])(
+    'returns a GraphQLError when timestamp is %s',
+    async (title, ts) => {
+      const response = await request(HOST)
+        .post('/')
+        .set('Content-type', 'application/json')
+        .send(
+          JSON.stringify({
+            query: `query {  blocks (where: { ts: ${ts}, network_in: ["1"] }) {network number}}`,
+            variables: null
+          })
+        );
+
+      expect(response.body.errors).toEqual([
+        {
+          extensions: {
+            code: 'INVALID_TIMESTAMP'
+          },
+          locations: [
+            {
+              column: 10,
+              line: 1
+            }
+          ],
+          message: 'timestamp must be in the past',
+          path: ['blocks']
+        }
+      ]);
+    },
+    15e3
+  );
 });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When passing invalid timestamp, it returns the following response:

```
{
      "message": "Int cannot represent non-integer value: NaN",
      "locations": [
        {
          "line": 1,
          "column": 87
        }
      ],
      "path": [
        "blocks",
        0,
        "number"
      ]
    },
```

which does not explain what is wrong

## 💊 Fixes / Solution

Fix #312 

Catch invalid timestamp value earlier, to avoid sending graph request with invalid timestamp values, and return a meaningful error.

## 🚧 Changes

- Catch invalid timestamp (future || <= 0)
- Return a custom meaningful error on invalid timestamp
- Add test for invalid timestamp
- Add test for invalid network

## 🛠️ Tests

- Run `http://localhost:3034`
- Try sending query with invalid `ts` 
- it should return an error with `INVALID_TIMESTAMP` code