### PR TITLE
fix: fix error when given timestamp is returning latest block

### DIFF
--- a/src/graphql/blocks.ts
+++ b/src/graphql/blocks.ts
@@ -74,7 +74,7 @@ export default async function query(_parent, args) {
 
     return Object.entries(blockNumsObj).map((block: any) => ({
       network: block[0],
-      number: parseInt(block[1])
+      number: block[1]
     }));
   } catch (e: any) {
     if (e.status === 404) {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -43,6 +43,31 @@ describe('POST /', () => {
     });
   }, 15e3);
 
+  it('returns latest blocknumber from current timestamp', async () => {
+    const response = await request(HOST)
+      .post('/')
+      .set('Content-type', 'application/json')
+      .send(
+        JSON.stringify({
+          query: `query {  blocks (where: { ts: ${Math.floor(
+            Date.now() / 1000
+          )}, network_in: ["1"] }) {network number}}`,
+          variables: null
+        })
+      );
+
+    expect(response.body).toEqual({
+      data: {
+        blocks: [
+          {
+            network: '1',
+            number: 'latest'
+          }
+        ]
+      }
+    });
+  }, 15e3);
+
   it('returns the blocknumber from timestamp with value 0', async () => {
     const response = await request(HOST)
       .post('/')


### PR DESCRIPTION
This is a fix alternative for #50 

## 🧿 Current issues / What's wrong ?

When given timestamp is from the `latest` block, graphql is not able to return the latest string as `number` property (number is typed as int).

Previous fix (#50) is proposing adding a boolean `latest` field to signal that the timestamp is from latest block (and return `number` as null). 

This PR is proposing another alternative

## 💊 Fixes / Solution

Use a custom graphql scalar, and return either a blocknumber or the `latest` string as `number` property. Example result will looks like:

```json
{"data":{"blocks":[{"network":"1","number":"latest"}]}}
# or
{"data":{"blocks":[{"network":"1","number":18252546}]}}
```

## 🛠️ Tests

Use the following custom script:

```js
import fetch from 'cross-fetch';

function randomDelay(min, max) {
  return Math.floor(min + Math.random() * (max - min + 1));
}

(async () => {
  // run fetch for 25 times with 1 second interval
  const array = new Array(25).fill(0);
  for (const _ in array) {
    const ts = Math.floor(Date.now() / 1000 - randomDelay(0, 10));
    const query = `{"query":"\\nquery {\\n  blocks (where: { ts: ${ts}, network_in: [\\"1\\"] }) {\\n    network\\n    number\\n  }\\n}\\n"}`;
    console.log('Sending request', ts);
    const result = await fetch('http://localhost:3004/?', {
      headers: {
        accept: 'application/json',
        'accept-language': 'en-US,en;q=0.9',
        'content-type': 'application/json'
      },
      body: query,
      method: 'POST'
    });
    // console.log(query);
    console.log(JSON.stringify(await result.json()));
    await new Promise(resolve => setTimeout(resolve, 1000));
  }
})();
```

Run it with `yarn ts-node script.ts`