### PR TITLE
fix: ensure variable exist before using

### DIFF
--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -13,7 +13,7 @@ export async function getBlock(network: string, blockNum: number) {
   const provider = snapshot.utils.getProvider(network);
   const block = await provider.getBlock(blockNum);
 
-  if (block.timestamp) {
+  if (block?.timestamp) {
     if (!blocks[network]) blocks[network] = {};
     blocks[network][`_${block.timestamp}`] = block.number;
 


### PR DESCRIPTION
Check that variable is not null before manipulation