### PR TITLE
Revert "chore(deps): bump @snapshot-labs/snapshot.js from 0.12.36 to 0.12.37"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@graphql-tools/schema": "^8.3.10",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.5",
-    "@snapshot-labs/snapshot.js": "^0.12.37",
+    "@snapshot-labs/snapshot.js": "^0.12.36",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,10 +1200,10 @@
   dependencies:
     "@sentry/node" "^7.81.1"
 
-"@snapshot-labs/snapshot.js@^0.12.37":
-  version "0.12.37"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.12.37.tgz#13fa2037c9ffb9d6a3262a43bd8970a6128ac240"
-  integrity sha512-tsK6Ef2KDqnInYcZNcnjLV9GBpa8jralutMc4beQexr74SQ34NPshlKah0OeaXxkM6cdtFbQH6bXLUXwz1hBhg==
+"@snapshot-labs/snapshot.js@^0.12.36":
+  version "0.12.36"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.12.36.tgz#89ff38be1b2ab2b239ab5caf0b20c5c4e65eed4e"
+  integrity sha512-cCwX8mLattshjMLzb731DWDQ8/D0uHINBjTNyFhdyxwW/7B1Dr4wAIQHR+iXwJDA3aiqDJPIP6llD1HRRllvBQ==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"


### PR DESCRIPTION
Reverts snapshot-labs/blockfinder#445