### PR TITLE
build: ignore typecheck error from dependencies

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "Node",
     "sourceMap": true,
     "inlineSources": true,
-    "sourceRoot": "/"
+    "sourceRoot": "/",
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Fix build error when typechecking dependencies: fix https://github.com/snapshot-labs/blockfinder/pull/478