### PR TITLE
chore: group @snapshot-labs/* dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@snapshot-labs/*"
+    groups:
+      snapshot:
+        patterns:
+          - '@snapshot-labs/*'


### PR DESCRIPTION
Adds a \`snapshot\` dependabot group so all \`@snapshot-labs/*\` bumps land as one grouped PR per cycle instead of one PR per package. Mirrors the pattern already in sx-monorepo + delegate-registry-api.

cc @ChaituVR