### PR TITLE
fix: initialize Sentry before express is imported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 import 'dotenv/config';
-// Keep between dotenv/config and express: it needs SENTRY_DSN loaded, and Sentry
-// instruments express at init. Moving it either way fails silently.
 import './instrument';
 import { fallbackLogger } from '@snapshot-labs/snapshot-sentry';
 import cors from 'cors';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import 'dotenv/config';
-import { fallbackLogger, initLogger } from '@snapshot-labs/snapshot-sentry';
+// Keep between dotenv/config and express: it needs SENTRY_DSN loaded, and Sentry
+// instruments express at init. Moving it either way fails silently.
+import './instrument';
+import { fallbackLogger } from '@snapshot-labs/snapshot-sentry';
 import cors from 'cors';
 import express from 'express';
 import graphql from './graphql';
@@ -8,7 +11,6 @@ import initMetrics from './helpers/metrics';
 const app = express();
 const PORT = process.env.PORT || 3004;
 
-initLogger();
 initMetrics(app);
 
 app.disable('x-powered-by');

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,0 +1,3 @@
+import { initLogger } from '@snapshot-labs/snapshot-sentry';
+
+initLogger();


### PR DESCRIPTION
## Problem

Since `@snapshot-labs/snapshot-sentry` v2 the wrapper sits on `@sentry/node` v10, which instruments Express by patching the module as it is required. `Sentry.init` has to run before `express` is imported, or the patch never lands.

`initLogger()` is called in `src/index.ts` after the import block, and under CommonJS the imports are all required first, so Express is already loaded by the time Sentry initialises.

This came in with the v2 signature change, where `initLogger(app)` became `initLogger()`. On the old SDK that `app` argument was what hooked Express; dropping it was correct for the new signature, but nothing took the job over. Errors kept arriving in Sentry throughout, so nothing looked wrong.

## Fix

Move the call into `src/instrument.ts` and import that first in `src/index.ts`, matching the pattern the other services already on this major use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
