### PR TITLE
chore(deps): bump typescript to 5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "graphql-fields": "^2.0.3",
     "nodemon": "^2.0.20",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4"
+    "typescript": "~5.5.3"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "graphql-fields": "^2.0.3",
     "nodemon": "^2.0.20",
     "ts-node": "^10.9.1",
-    "typescript": "~5.5.3"
+    "typescript": "^5.8.3"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5207,10 +5207,10 @@ typescript-eslint@^8.29.1:
     "@typescript-eslint/typescript-estree" "8.60.0"
     "@typescript-eslint/utils" "8.60.0"
 
-typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@~5.5.3:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 undefsafe@^2.0.5:
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5207,10 +5207,10 @@ typescript-eslint@^8.29.1:
     "@typescript-eslint/typescript-estree" "8.60.0"
     "@typescript-eslint/utils" "8.60.0"
 
-typescript@~5.5.3:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
-  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
+typescript@^5.8.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 undefsafe@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
blockfinder was still building on TypeScript 4 while snapshot.js and the rest of the org are on TypeScript 5. This brings the compiler in line with the version snapshot.js itself resolves.

No source changes were needed.
